### PR TITLE
楽天APIを読み込めるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'rakuten_web_service'
+gem 'dotenv-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,10 @@ GEM
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -117,6 +121,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json (2.7.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -191,6 +196,8 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.1.0)
+    rakuten_web_service (1.13.2)
+      json (~> 2.3)
     rdoc (6.6.2)
       psych (>= 4.0.0)
     regexp_parser (2.8.3)
@@ -247,10 +254,12 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   puma (>= 5.0)
   rails (~> 7.1.2)
+  rakuten_web_service
   selenium-webdriver
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,0 +1,14 @@
+
+class RecipesController < ApplicationController
+  def index
+    @recipes = Recipe.all
+  end
+
+  def show; end
+
+  private
+
+  def set_recipe
+    @recipe = Recipe.order("RANDOM()").first
+  end
+end

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -1,0 +1,2 @@
+module RecipesHelper
+end

--- a/app/models/access_rakuten_recipe_api.rb
+++ b/app/models/access_rakuten_recipe_api.rb
@@ -1,0 +1,26 @@
+require 'net/http'
+
+class AccessRakutenRecipeApi
+  RWS_APPLICATION_ID = ENV['RWS_APPLICATION_ID']
+  class << self
+    def search(params = {})
+      # paramsを使って柔軟に検索パラメータを追加できる想定
+      # （だが、下記URLは静的なレスポンスしか返さないので未実装）
+      uri = URI.parse("https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426?format=json&categoryId=36-491-1670&applicationId=#{RWS_APPLICATION_ID}")
+      json = Net::HTTP.get(uri)
+      data_list = JSON.parse(json, symbolize_names: true)
+      filtered_data_list = data_list[:result].map do |recipe_data|
+        {
+          recipeTitle: recipe_data[:recipeTitle],
+          foodImageUrl: recipe_data[:foodImageUrl],
+          recipeUrl: recipe_data[:recipeUrl],
+          recipeMaterial: recipe_data[:recipeMaterial],
+          recipeCost: recipe_data[:recipeCost],
+          recipeIndication: recipe_data[:recipeIndication]
+        }
+      end
+
+      filtered_data_list.map { |data| Recipe.new(data) }
+    end
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,0 +1,21 @@
+class Recipe
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :recipeTitle, :string
+  attribute :foodImageUrl, :string
+  attribute :recipeUrl, :string
+  attribute :recipeMaterial, default: []
+  attribute :recipeCost, :string
+  attribute :recipeIndication, :string
+
+  class << self
+    def all
+      AccessRakutenRecipeApi.search
+    end
+  end
+
+  def has_error?
+    status.to_s.match?(/^[45]/)
+  end
+end

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,0 +1,21 @@
+<h1>Recipe List</h1>
+<table class="access-log-table table">
+  <body>
+    <% @recipes.each do |recipe| %>
+      <ul>
+        <li>title</li>
+        <p><%= recipe.recipeTitle %></p>
+        <li>image</li>
+        <p><%= image_tag recipe.foodImageUrl, alt: 'Recipe Image', size: '358x358' %></p>
+        <li>URL</li>
+        <p><%= link_to recipe.recipeUrl %></p>
+        <li>material</li>
+        <p><%= recipe.recipeMaterial.join(', ') %></p>
+        <li>cost</li>
+        <p><%= recipe.recipeCost %></p>
+        <li>time</li>
+        <p><%= recipe.recipeIndication %></p>
+      </ul>
+    <% end %>
+  </body>
+</table>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,0 +1,24 @@
+<a href="https://cookpad.com/search/%EF%BC%93%E5%88%86%20%E3%81%8A%E3%81%A4%E3%81%BE%E3%81%BF?order=">ここをクリックすると飛びます。</a>
+
+<div class = 'container'>
+  <div class = 'child'>
+    <% if @recipe.present? %>
+      <ul>
+        <li>title</li>
+        <p><%= recipe.recipeTitle %></p>
+        <li>image</li>
+        <p><%= image_tag recipe.foodImageUrl, alt: 'Recipe Image', size: '358x358' %></p>
+        <li>URL</li>
+        <p><%= link_to recipe.recipeUrl %></p>
+        <li>material</li>
+        <p><%= recipe.recipeMaterial.join(', ') %></p>
+        <li>cost</li>
+        <p><%= recipe.recipeCost %></p>
+        <li>time</li>
+        <p><%= recipe.recipeIndication %></p>
+      </ul>
+    <% else %>
+      <h2>レシピが見つかりません</h2>
+    <% end %>
+  </div>
+</div>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -1,2 +1,12 @@
-<h1>Staticpages#top</h1>
-<p>Find me in app/views/staticpages/top.html.erb</p>
+<div class= 'container'>
+  <div class = 'child'>
+    <br>
+    <h1>3分で作れるおつまみレシピ</h1>
+    <h2>今日のおつまみは何にしよう</h2>
+    <br>
+    <div>
+      <p>下のボタンからおつまみがランダムで選ばれるよ</p>
+      <%= link_to 'スタート', "#", class: "btn" %>
+    </div>
+  </div>
+</div>

--- a/config/initializers/rakuten.rb
+++ b/config/initializers/rakuten.rb
@@ -1,0 +1,4 @@
+RakutenWebService.configure do |c|
+  # (必須) アプリケーションID
+  c.application_id = ENV['RWS_APPLICATION_ID']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get 'staticpages/top'
   root "staticpages#top"
+  get 'recipes', to: 'recipes#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/recipes_controller_test.rb
+++ b/test/controllers/recipes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecipesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要 ### 

- 楽天レシピAPIをrailsに呼び出す

### 内容 ### 
1. 楽天APIのアプリケーションIDを取得

2. config/routes.rbと.envに取得したIDを定義（.envにはIDが記載されてるので、gitignoere）

3. 外部APIを取得するための、access_rakuten_recipe_api.rbとrecipe.rbモデルを作成。
   参考： [https://qiita.com/jnchito/items/2a168b9083bc911981fa](url)

4. ビューとコントローラーを作成。